### PR TITLE
res.response.to_ary[1] will be removed

### DIFF
--- a/Gyazo.app/Contents/Resources/script
+++ b/Gyazo.app/Contents/Resources/script
@@ -62,7 +62,7 @@ header ={
 
 Net::HTTP.start(HOST,80){|http|
   res = http.post(CGI,data,header)
-  url = res.response.to_ary[1]
+  url = res.response.body
   system "echo -n #{url} | pbcopy"
   system "open #{url}"
 


### PR DESCRIPTION
Now Gyazo.app doesn't work with ruby-head because `to_ary` is removed at head.

Use `body` method instead.
